### PR TITLE
Add success job to the end of the CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         backend-tests,
       ]
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - name: Pipeline succeeded
+        if: "!contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')"
         run: echo "All checks passed successfully!"


### PR DESCRIPTION
I am tired of having to change the branch protection rules every time I update the CI pipeline 😵‍💫

This PR adds a new stage to the end of the CI pipeline that I called `Pipeline success`. This job depends on all previous jobs.

Now I only need to add this job to the branch protection rules, and it will ensure the entire pipeline has passed before allowing merges.