### PR TITLE
Added failure handling to the success job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,8 @@ jobs:
       - name: Pipeline succeeded
         if: "!contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')"
         run: echo "All checks passed successfully!"
+      - name: Pipeline failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "Some checks failed or were cancelled."
+          exit 1


### PR DESCRIPTION
If one of the previous jobs fails or gets cancelled, the `success` job will fail.