### PR TITLE
Fix Pydantic warning about loading env variables

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,5 +1,5 @@
 from dotenv import load_dotenv
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 load_dotenv()
 
@@ -9,8 +9,7 @@ class Settings(BaseSettings):
     MEILISEARCH_MASTER_KEY: str = "aStrongMasterKey"
     MEILISEARCH_INDEX_NAME: str = "articles"
 
-    class Config:
-        env_file = "../env"
+    model_config = SettingsConfigDict(env_file="../env")
 
 
 settings = Settings()


### PR DESCRIPTION
In the newer versions of `Pydantic`, it won't be possible to load env variables using the following code block:

```python
class Settings(BaseSettings):
    ...

    class Config:
        env_file = "../env"


settings = Settings()
```

`class Config` should be replaced with `SettingsConfigDict()` like this:

```python
class Settings(BaseSettings):
    ...

    model_config = SettingsConfigDict(env_file="../env")

settings = Settings()
```
