### PR TITLE
Updated the rsync exclude list

### DIFF
--- a/rsync_exclude.txt
+++ b/rsync_exclude.txt
@@ -10,6 +10,7 @@ rsync_exclude.txt
 backups/
 
 frontend/node_modules/
+frontend/dist/analytics.html
 
 backend/venv/
 backend/__pycache__/


### PR DESCRIPTION
Since I am using `GoAccess` to generate an HTML report, I updated the exclude list to prevent `rsync` from deleting the html file.