### PR TITLE
Replaced udemy with GitHub sponsors and Patreon

### DIFF
--- a/frontend/src/courses/ElasticsearchForBeginners/content.md
+++ b/frontend/src/courses/ElasticsearchForBeginners/content.md
@@ -25,4 +25,5 @@ All course materials, slides, and Jupyter notebooks are available on my [GitHub 
 
 I believe knowledge should be free, so I am sharing this course for free on the freeCodeCamp YouTube channel. You can watch the full course below.
 
-Creating courses like this takes months of research, experiments, designing illustrations, recording, and more. If you want to support my mission to share free knowledge, you can also watch the course on [Udemy](https://www.udemy.com/course/train-your-own-language-model/). The Udemy version includes extra content, such as quizzes, assignments, and a certificate of completion.
+Creating courses like this takes months of research, experiments, designing illustrations, recording, and more.
+If you want to support my mission to share free knowledge, you can [sponsor me on GitHub](https://github.com/sponsors/ImadSaddik) or [support me on Patreon](https://www.patreon.com/3CodeCamp).

--- a/frontend/src/courses/ElasticsearchForBeginners/index.vue
+++ b/frontend/src/courses/ElasticsearchForBeginners/index.vue
@@ -59,9 +59,9 @@
       <YouTubePlayer video-url="https://www.youtube.com/embed/a4HBKEda_F8" />
       <p>
         Creating courses like this takes months of research, experiments, designing illustrations, recording, and more.
-        If you want to support my mission to share free knowledge, you can also watch the course on
-        <a href="https://www.udemy.com/course/train-your-own-language-model/" target="_blank">Udemy</a>. The Udemy
-        version includes extra content, such as quizzes, assignments, and a certificate of completion.
+        If you want to support my mission to share free knowledge, you can
+        <a href="https://github.com/sponsors/ImadSaddik" target="_blank">sponsor me on GitHub</a>
+        or <a href="https://www.patreon.com/3CodeCamp" target="_blank">support me on Patreon</a>.
       </p>
     </section>
   </ArticleLayout>

--- a/frontend/src/courses/EvolutionOfTheTransformer/content.md
+++ b/frontend/src/courses/EvolutionOfTheTransformer/content.md
@@ -23,4 +23,5 @@ By the end of the course, you will build several models using the ideas we discu
 
 I believe knowledge should be free, so I am sharing this course for free on the freeCodeCamp YouTube channel. You can watch the full course below.
 
-Creating courses like this takes months of research, experiments, designing illustrations, recording, and more. If you want to support my mission to share free knowledge, you can also watch the course on [Udemy](https://www.udemy.com/course/train-your-own-language-model/). The Udemy version includes extra content, such as quizzes, assignments, and a certificate of completion.
+Creating courses like this takes months of research, experiments, designing illustrations, recording, and more.
+If you want to support my mission to share free knowledge, you can [sponsor me on GitHub](https://github.com/sponsors/ImadSaddik) or [support me on Patreon](https://www.patreon.com/3CodeCamp).

--- a/frontend/src/courses/EvolutionOfTheTransformer/index.vue
+++ b/frontend/src/courses/EvolutionOfTheTransformer/index.vue
@@ -58,9 +58,9 @@
       <YouTubePlayer video-url="https://www.youtube.com/embed/8WBS0dT0h2I" />
       <p>
         Creating courses like this takes months of research, experiments, designing illustrations, recording, and more.
-        If you want to support my mission to share free knowledge, you can also watch the course on
-        <a href="https://www.udemy.com/course/train-your-own-language-model/" target="_blank">Udemy</a>. The Udemy
-        version includes extra content, such as quizzes, assignments, and a certificate of completion.
+        If you want to support my mission to share free knowledge, you can
+        <a href="https://github.com/sponsors/ImadSaddik" target="_blank">sponsor me on GitHub</a>
+        or <a href="https://www.patreon.com/3CodeCamp" target="_blank">support me on Patreon</a>.
       </p>
     </section>
   </ArticleLayout>

--- a/frontend/src/courses/OSRMForBeginners/content.md
+++ b/frontend/src/courses/OSRMForBeginners/content.md
@@ -29,4 +29,5 @@ All course materials, slides, and Jupyter notebooks are available on my [GitHub 
 
 I believe knowledge should be free, so I am sharing this course for free on the freeCodeCamp YouTube channel. You can watch the full course below.
 
-Creating courses like this takes months of research, experiments, designing illustrations, recording, and more. If you want to support my mission to share free knowledge, you can also watch the course on [Udemy](https://www.udemy.com/course/train-your-own-language-model/). The Udemy version includes extra content, such as quizzes, assignments, and a certificate of completion.
+Creating courses like this takes months of research, experiments, designing illustrations, recording, and more.
+If you want to support my mission to share free knowledge, you can [sponsor me on GitHub](https://github.com/sponsors/ImadSaddik) or [support me on Patreon](https://www.patreon.com/3CodeCamp).

--- a/frontend/src/courses/OSRMForBeginners/index.vue
+++ b/frontend/src/courses/OSRMForBeginners/index.vue
@@ -55,9 +55,9 @@
       <YouTubePlayer video-url="https://www.youtube.com/embed/o9Bgwq_H-rE" />
       <p>
         Creating courses like this takes months of research, experiments, designing illustrations, recording, and more.
-        If you want to support my mission to share free knowledge, you can also watch the course on
-        <a href="https://www.udemy.com/course/train-your-own-language-model/" target="_blank">Udemy</a>. The Udemy
-        version includes extra content, such as quizzes, assignments, and a certificate of completion.
+        If you want to support my mission to share free knowledge, you can
+        <a href="https://github.com/sponsors/ImadSaddik" target="_blank">sponsor me on GitHub</a>
+        or <a href="https://www.patreon.com/3CodeCamp" target="_blank">support me on Patreon</a>.
       </p>
     </section>
   </ArticleLayout>

--- a/frontend/src/courses/TrainYourOwnLanguageModel/content.md
+++ b/frontend/src/courses/TrainYourOwnLanguageModel/content.md
@@ -21,4 +21,5 @@ Each step is divided into two parts: `theory` and `practice`. The theory is expl
 
 I believe knowledge should be free, so I am sharing this course for free on the freeCodeCamp YouTube channel. You can watch the full course below.
 
-Creating courses like this takes months of research, experiments, designing illustrations, recording, and more. If you want to support my mission to share free knowledge, you can also watch the course on [Udemy](https://www.udemy.com/course/train-your-own-language-model/). The Udemy version has extra content, including quizzes, assignments, and a certificate of completion.
+Creating courses like this takes months of research, experiments, designing illustrations, recording, and more.
+If you want to support my mission to share free knowledge, you can [sponsor me on GitHub](https://github.com/sponsors/ImadSaddik) or [support me on Patreon](https://www.patreon.com/3CodeCamp).

--- a/frontend/src/courses/TrainYourOwnLanguageModel/index.vue
+++ b/frontend/src/courses/TrainYourOwnLanguageModel/index.vue
@@ -60,9 +60,9 @@
       <YouTubePlayer video-url="https://www.youtube.com/embed/9Ge0sMm65jo" />
       <p>
         Creating courses like this takes months of research, experiments, designing illustrations, recording, and more.
-        If you want to support my mission to share free knowledge, you can also watch the course on
-        <a href="https://www.udemy.com/course/train-your-own-language-model/" target="_blank">Udemy</a>. The Udemy
-        version has extra content, including quizzes, assignments, and a certificate of completion.
+        If you want to support my mission to share free knowledge, you can
+        <a href="https://github.com/sponsors/ImadSaddik" target="_blank">sponsor me on GitHub</a>
+        or <a href="https://www.patreon.com/3CodeCamp" target="_blank">support me on Patreon</a>.
       </p>
     </section>
   </ArticleLayout>


### PR DESCRIPTION
This PR removed Udemy from the courses articles. I don't have time to remodel the YouTube videos to make suitable for Udemy.