### PR TITLE
Added dependabot to automatically updated the project's dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "pip"
+    directory: "/dashboard_analysis"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR adds dependabot to the repository to help me automatically keep my project's dependencies up-to-date.

This is important for security.