### PR TITLE
Update Nginx configuration to serve resume.pdf as well

### DIFF
--- a/infrastructure/nginx/imadsaddik.com
+++ b/infrastructure/nginx/imadsaddik.com
@@ -36,7 +36,7 @@ server {
     # --- Application routes ---
 
     # C. Resume PDF
-    location = ~ ^/resume(\.pdf)?$ {
+    location ~ ^/resume(\.pdf)?$ {
         alias /web_app/frontend/dist/imad_saddik.pdf;
         default_type application/pdf;
         add_header Content-Disposition "inline; filename=imad_saddik.pdf";


### PR DESCRIPTION
The old Nginx configuration only knew what `/resume` is. It didn't know what `/resume.pdf` is, so in that case it sends back the Vue app (index.html) instead.

This PR fixes this issue by using the following regular expression: `~ ^/resume(\.pdf)?$`