### PR TITLE
Sanitize error messages sent to the frontend

### DIFF
--- a/backend/api/article.py
+++ b/backend/api/article.py
@@ -35,8 +35,8 @@ async def increment_article_view_count(name: str):
 
     except HTTPException:
         raise
-    except Exception as e:
-        logger.exception(f"Error incrementing view count for article '{name}': {e}")
+    except Exception:
+        logger.exception(f"Error incrementing view count for article '{name}'")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -59,8 +59,8 @@ async def increment_article_read_count(name: str):
 
     except HTTPException:
         raise
-    except Exception as e:
-        logger.exception(f"Error incrementing read count for article '{name}': {e}")
+    except Exception:
+        logger.exception(f"Error incrementing read count for article '{name}'")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -83,8 +83,8 @@ async def increment_article_claps_count(name: str):
 
     except HTTPException:
         raise
-    except Exception as e:
-        logger.exception(f"Error incrementing claps count for article '{name}': {e}")
+    except Exception:
+        logger.exception(f"Error incrementing claps count for article '{name}'")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -94,8 +94,8 @@ async def get_article_recommendations(request: RecommendationArticleRequest):
         recommendations = await meilisearch_service.get_article_recommendations(request)
         return recommendations
 
-    except Exception as e:
-        logger.exception(f"Error getting article recommendations: {e}")
+    except Exception:
+        logger.exception("Error getting article recommendations")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -107,8 +107,8 @@ async def get_latest_articles(request: LatestArticleRequest):
         )
         return latest_articles
 
-    except Exception as e:
-        logger.exception(f"Error getting latest articles: {e}")
+    except Exception:
+        logger.exception("Error getting latest articles")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -130,6 +130,6 @@ async def get_article_claps_count(name: str):
 
     except HTTPException:
         raise
-    except Exception as e:
-        logger.exception(f"Error getting claps count for article '{name}': {e}")
+    except Exception:
+        logger.exception(f"Error getting claps count for article '{name}'")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/api/search.py
+++ b/backend/api/search.py
@@ -16,6 +16,6 @@ async def search_articles(request: SearchRequest):
 
     except HTTPException:
         raise
-    except Exception as e:
-        logger.exception(f"Error searching articles with query '{request.query}': {e}")
+    except Exception:
+        logger.exception(f"Error searching articles with query '{request.query}'")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/api/visitors.py
+++ b/backend/api/visitors.py
@@ -33,5 +33,5 @@ async def _track_task(client_ip: str | None = None, visited_page: str = "HOME") 
                 visited_page=visited_page,
                 is_bot=ip_api_response.is_bot,
             )
-    except Exception as e:
-        logger.exception(f"Error tracking visitor via endpoint: {e}")
+    except Exception:
+        logger.exception("Error tracking visitor via endpoint")

--- a/backend/services/geolocation.py
+++ b/backend/services/geolocation.py
@@ -39,6 +39,6 @@ async def get_country_and_check_bot_from_ip(ip_address: str) -> IpAPIResponse:
                 return IpAPIResponse(country=location["country"], is_bot=False)
 
             return IpAPIResponse(country=None, is_bot=False)
-        except Exception as e:
-            logger.exception(f"Error calling ipapi.is: {e}")
+        except Exception:
+            logger.exception("Error calling ipapi.is")
             return IpAPIResponse(country=None, is_bot=False)

--- a/backend/services/meilisearch.py
+++ b/backend/services/meilisearch.py
@@ -113,8 +113,8 @@ class MeilisearchService:
                 "view_count": new_view_count,
             }
 
-        except Exception as e:
-            logger.exception(f"Error incrementing view count for document '{document_name}': {e}")
+        except Exception:
+            logger.exception(f"Error incrementing view count for document '{document_name}'")
             return {"success": False, "message": "Internal server error", "view_count": 0}
 
     async def increment_read_count(self, document_name: str) -> dict:
@@ -140,8 +140,8 @@ class MeilisearchService:
                 "read_count": new_read_count,
             }
 
-        except Exception as e:
-            logger.exception(f"Error incrementing read count for document '{document_name}': {e}")
+        except Exception:
+            logger.exception(f"Error incrementing read count for document '{document_name}'")
             return {"success": False, "message": "Internal server error", "read_count": 0}
 
     async def increment_claps_count(self, document_name: str) -> dict:
@@ -167,8 +167,8 @@ class MeilisearchService:
                 "claps_count": new_claps_count,
             }
 
-        except Exception as e:
-            logger.exception(f"Error incrementing claps count for document '{document_name}': {e}")
+        except Exception:
+            logger.exception(f"Error incrementing claps count for document '{document_name}'")
             return {"success": False, "message": "Internal server error", "claps_count": 0}
 
     async def get_article_recommendations(self, data: RecommendationArticleRequest) -> RecommendationArticleResponse:
@@ -255,8 +255,8 @@ class MeilisearchService:
                 "claps_count": chunks[0].claps_count,
             }
 
-        except Exception as e:
-            logger.exception(f"Error retrieving claps count for document '{document_name}': {e}")
+        except Exception:
+            logger.exception(f"Error retrieving claps count for document '{document_name}'")
             return {
                 "success": False,
                 "message": "Internal server error",


### PR DESCRIPTION
This PR changed the error messages that are sent to the frontend. Instead of sending the full stack trace, the backend sends a generic message.

The developer can still see the full stack trace in the logs to debug any issue that the server is experiencing.