### PR TITLE
Fix tmux pane indexing to work with my new config

### DIFF
--- a/bash_scripts/run_all_services_tmux.sh
+++ b/bash_scripts/run_all_services_tmux.sh
@@ -18,16 +18,13 @@ FRONTEND_CMD="pnpm run dev"
 tmux kill-session -t $SESSION_NAME 2>/dev/null
 tmux new-session -d -s $SESSION_NAME -n "Dev"
 
-# Split the window to create a new pane on top for the other services.
-tmux split-window -v -p 50 -t "$SESSION_NAME:1.1"
+PANE_TOP_LEFT_ID=$(tmux list-panes -t "$SESSION_NAME" -F '#{pane_id}')
+PANE_BOTTOM_ID=$(tmux split-window -v -p 50 -t "$PANE_TOP_LEFT_ID" -P -F '#{pane_id}')
+PANE_TOP_RIGHT_ID=$(tmux split-window -h -p 50 -t "$PANE_TOP_LEFT_ID" -P -F '#{pane_id}')
 
-# Select the top pane and split it horizontally.
-tmux select-pane -t "$SESSION_NAME:1.1"
-tmux split-window -h -p 50 -t "$SESSION_NAME:1.1"
-
-# Start services in their respective panes
-tmux send-keys -t "$SESSION_NAME:1.1" "echo 'Starting Meilisearch...'; cd '$MEILISEARCH_DIR' && $MEILISEARCH_CMD" C-m
-tmux send-keys -t "$SESSION_NAME:1.2" "echo 'Starting Frontend...'; $BASH_ENV_CMD && cd '$FRONTEND_DIR' && $FRONTEND_CMD" C-m
-tmux send-keys -t "$SESSION_NAME:1.3" "echo 'Starting Backend...'; $BASH_ENV_CMD && cd '$BACKEND_DIR' && $BACKEND_CMD" C-m
+# Start services in their respective panes using their unique IDs
+tmux send-keys -t "$PANE_TOP_LEFT_ID" "echo 'Starting Meilisearch...'; cd '$MEILISEARCH_DIR' && $MEILISEARCH_CMD" C-m
+tmux send-keys -t "$PANE_TOP_RIGHT_ID" "echo 'Starting Frontend...'; $BASH_ENV_CMD && cd '$FRONTEND_DIR' && $FRONTEND_CMD" C-m
+tmux send-keys -t "$PANE_BOTTOM_ID" "echo 'Starting Backend...'; $BASH_ENV_CMD && cd '$BACKEND_DIR' && $BACKEND_CMD" C-m
 
 tmux attach-session -t $SESSION_NAME

--- a/bash_scripts/stop_all_services_tmux.sh
+++ b/bash_scripts/stop_all_services_tmux.sh
@@ -4,9 +4,7 @@ SESSION_NAME="imad_saddik_personal_website"
 
 if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
   echo "Session found. Stopping services..."
-  tmux send-keys -t "$SESSION_NAME:1.1" C-c
-  tmux send-keys -t "$SESSION_NAME:1.2" C-c
-  tmux send-keys -t "$SESSION_NAME:1.3" C-c
+  tmux list-panes -t "$SESSION_NAME" -F '#{pane_id}' | xargs -I paneID tmux send-keys -t paneID C-c
   sleep 1
   tmux kill-session -t "$SESSION_NAME"
   echo "Session '$SESSION_NAME' stopped."


### PR DESCRIPTION
This PR updates the `run_all_services_tmux.sh` script to start indexing from 1 to match my `tmux` config.