### PR TITLE
Remove "note" and keep "info" in AdmonitionBlock

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -8,37 +8,37 @@
 >
     <url>
         <loc>https://imadsaddik.com/</loc>
-        <lastmod>2026-01-19T14:27:46.207Z</lastmod>
+        <lastmod>2026-01-19T14:50:36.503Z</lastmod>
         <changefreq>daily</changefreq>
         <priority>1.0</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/about-me</loc>
-        <lastmod>2026-01-19T14:27:46.207Z</lastmod>
+        <lastmod>2026-01-19T14:50:36.503Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/hire-me</loc>
-        <lastmod>2026-01-19T14:27:46.207Z</lastmod>
+        <lastmod>2026-01-19T14:50:36.503Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/resume</loc>
-        <lastmod>2026-01-19T14:27:46.207Z</lastmod>
+        <lastmod>2026-01-19T14:50:36.503Z</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.5</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/blogs/elasticsearch-change-heap-size</loc>
-        <lastmod>2026-01-18T11:40:42.831Z</lastmod>
+        <lastmod>2026-01-19T14:47:44.833Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/blogs/elasticsearch-collapse-search-results</loc>
-        <lastmod>2026-01-18T11:40:42.831Z</lastmod>
+        <lastmod>2026-01-19T14:47:45.182Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
@@ -56,7 +56,7 @@
     </url>
     <url>
         <loc>https://imadsaddik.com/blogs/how-to-set-up-a-secure-cloud-server-with-ubuntu-and-ssh</loc>
-        <lastmod>2026-01-19T14:25:13.758Z</lastmod>
+        <lastmod>2026-01-19T14:47:44.801Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
@@ -68,7 +68,7 @@
     </url>
     <url>
         <loc>https://imadsaddik.com/blogs/local-ai-stack-on-linux</loc>
-        <lastmod>2026-01-18T11:40:42.832Z</lastmod>
+        <lastmod>2026-01-19T14:47:45.134Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -151,8 +151,6 @@ export default {
   --color-toast-info-foreground: #000000;
 
   /* Admonition colors */
-  --color-admonition-note-background: #9ca3af1a;
-  --color-admonition-note-border: #9ca3af;
   --color-admonition-tip-background: #22c55e1a;
   --color-admonition-tip-border: #22c55e;
   --color-admonition-info-background: #5996f71a;

--- a/frontend/src/blogs/elasticsearch-change-heap-size/index.vue
+++ b/frontend/src/blogs/elasticsearch-change-heap-size/index.vue
@@ -66,7 +66,7 @@
         <div>
           <p>Open your terminal and run:</p>
           <CodeBlock :code="bashCodeSnippet1" language="bash" @show-toast="handleShowToastEvent" />
-          <AdmonitionBlock title="Note" type="note">
+          <AdmonitionBlock title="Info" type="info">
             <p>
               If you assigned a different name to the container, replace <InlineCode text="elasticsearch" /> with that
               name in the command.

--- a/frontend/src/blogs/elasticsearch-collapse-search-results/index.vue
+++ b/frontend/src/blogs/elasticsearch-collapse-search-results/index.vue
@@ -210,7 +210,7 @@
             <InlineCode text="search_after" /> parameter to paginate through the results. This is useful when you want
             to retrieve all collapsed results without missing any.
           </p>
-          <AdmonitionBlock title="Note" type="note">
+          <AdmonitionBlock title="Info" type="info">
             <p>
               You can't use the <InlineCode text="scroll API" /> with collapsing. Use
               <InlineCode text="search_after" /> instead.

--- a/frontend/src/blogs/how-to-set-up-a-secure-cloud-server-with-ubuntu-and-ssh/index.vue
+++ b/frontend/src/blogs/how-to-set-up-a-secure-cloud-server-with-ubuntu-and-ssh/index.vue
@@ -251,7 +251,7 @@
 
       <p>I strongly recommend adding a passphrase for your personal key.</p>
       lock down the
-      <AdmonitionBlock title="Note" type="note">
+      <AdmonitionBlock title="Info" type="info">
         <p>
           If you need a key for a CI/CD pipeline later (to deploy code automatically), generate a separate key pair
           without a passphrase. Never remove the passphrase from your personal key.
@@ -514,7 +514,7 @@
 
       <p>Both errors mean the same thing: The root account is now locked against remote login.</p>
 
-      <AdmonitionBlock title="Note" type="note">
+      <AdmonitionBlock title="Info" type="info">
         <p>
           Setting <InlineCode text="PasswordAuthentication no" /> is optional because DigitalOcean already disabled
           password authentication when you created the droplet (assuming you selected SSH key authentication).

--- a/frontend/src/blogs/local-ai-stack-on-linux/index.vue
+++ b/frontend/src/blogs/local-ai-stack-on-linux/index.vue
@@ -238,7 +238,7 @@
         <InlineCode text="llama-server" /> directly from any location.
       </p>
 
-      <AdmonitionBlock title="Note" type="note">
+      <AdmonitionBlock title="Info" type="info">
         <p>If you recompile the project, make sure to copy the programs again.</p>
       </AdmonitionBlock>
     </section>
@@ -1030,7 +1030,7 @@
         @open-image-modal="handleOpenImageModal"
       />
 
-      <AdmonitionBlock title="Note" type="note">
+      <AdmonitionBlock title="Info" type="info">
         <p>
           The diagram above is a conceptual illustration I made to help explain the process. It does not reflect the
           exact internal architecture of any specific model.
@@ -2203,7 +2203,7 @@ docker compose restart"
         <InlineCode text="--convert" /> flag when running the server.
       </p>
 
-      <AdmonitionBlock title="Note" type="note">
+      <AdmonitionBlock title="Info" type="info">
         <p>This FFmpeg integration is currently supported on <b>Linux only</b>.</p>
       </AdmonitionBlock>
 

--- a/frontend/src/components/AdmonitionBlock.vue
+++ b/frontend/src/components/AdmonitionBlock.vue
@@ -13,9 +13,9 @@ export default {
   props: {
     type: {
       type: String,
-      default: "note",
+      default: "info",
       validator(value) {
-        return ["note", "tip", "info", "warning", "danger"].includes(value);
+        return ["info", "tip", "warning", "danger"].includes(value);
       },
     },
     title: {
@@ -36,11 +36,6 @@ export default {
   padding: var(--gap-md);
   border-left: 5px solid;
   margin: var(--gap-md) 0;
-}
-
-.admonition-note {
-  background-color: var(--color-admonition-note-background);
-  border-color: var(--color-admonition-note-border);
 }
 
 .admonition-tip {
@@ -69,10 +64,6 @@ export default {
   margin-bottom: var(--gap-xs);
   font-size: var(--font-size-small);
   text-transform: capitalize;
-}
-
-.admonition-note .admonition-title {
-  color: var(--color-admonition-note-border);
 }
 
 .admonition-tip .admonition-title {

--- a/frontend/tests/unit/components/AdmonitionBlock.test.js
+++ b/frontend/tests/unit/components/AdmonitionBlock.test.js
@@ -5,8 +5,8 @@ describe("AdmonitionBlock", () => {
   const factory = (props = {}, slots = {}) =>
     mount(AdmonitionBlock, {
       props: {
-        title: "Note",
-        type: "note",
+        title: "Info",
+        type: "info",
         ...props,
       },
       slots: {
@@ -17,19 +17,19 @@ describe("AdmonitionBlock", () => {
 
   it("renders title and slot content", () => {
     const wrapper = factory();
-    expect(wrapper.find(".admonition-title").text()).toBe("Note");
+    expect(wrapper.find(".admonition-title").text()).toBe("Info");
     expect(wrapper.find(".admonition-content").text()).toContain("Some helpful information");
   });
 
-  it.each(["note", "tip", "info", "warning", "danger"])("applies correct class for type '%s'", (type) => {
+  it.each(["info", "tip", "warning", "danger"])("applies correct class for type '%s'", (type) => {
     const wrapper = factory({ type, title: type });
     expect(wrapper.find(".admonition").classes()).toContain(`admonition-${type}`);
     expect(wrapper.find(".admonition-content").text()).toContain("Some helpful information");
   });
 
-  it("defaults to note type when none provided", () => {
+  it("defaults to info type when none provided", () => {
     const wrapper = mount(AdmonitionBlock, { props: { title: "Default" }, slots: { default: "Default content" } });
-    expect(wrapper.find(".admonition").classes()).toContain("admonition-note");
+    expect(wrapper.find(".admonition").classes()).toContain("admonition-info");
     expect(wrapper.find(".admonition-content").text()).toContain("Default content");
   });
 });


### PR DESCRIPTION
# Pull request

## Description

This PR removes the `note` type from `AdmonitionBlock` because it is hard to distinguish between the two.

Closes #120 

## Screenshots or videos

The only possible types are now:

<img width="1421" height="567" alt="image" src="https://github.com/user-attachments/assets/2913cad4-9237-4a7e-8fcd-065fa973fe15" />

## Checklist

Check what applies:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have used LLMs responsibly to assist in writing code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed linting and formatting checks
- [ ] I have updated the documentation accordingly
