### PR TITLE
Revert to text interpolation in InlineCode component

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -8,37 +8,37 @@
 >
     <url>
         <loc>https://imadsaddik.com/</loc>
-        <lastmod>2026-01-19T14:50:36.503Z</lastmod>
+        <lastmod>2026-01-19T17:16:15.299Z</lastmod>
         <changefreq>daily</changefreq>
         <priority>1.0</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/about-me</loc>
-        <lastmod>2026-01-19T14:50:36.503Z</lastmod>
+        <lastmod>2026-01-19T17:16:15.299Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/hire-me</loc>
-        <lastmod>2026-01-19T14:50:36.503Z</lastmod>
+        <lastmod>2026-01-19T17:16:15.299Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/resume</loc>
-        <lastmod>2026-01-19T14:50:36.503Z</lastmod>
+        <lastmod>2026-01-19T17:16:15.299Z</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.5</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/blogs/elasticsearch-change-heap-size</loc>
-        <lastmod>2026-01-19T14:47:44.833Z</lastmod>
+        <lastmod>2026-01-19T17:04:11.251Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/blogs/elasticsearch-collapse-search-results</loc>
-        <lastmod>2026-01-19T14:47:45.182Z</lastmod>
+        <lastmod>2026-01-19T17:04:11.251Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
@@ -56,7 +56,7 @@
     </url>
     <url>
         <loc>https://imadsaddik.com/blogs/how-to-set-up-a-secure-cloud-server-with-ubuntu-and-ssh</loc>
-        <lastmod>2026-01-19T14:47:44.801Z</lastmod>
+        <lastmod>2026-01-19T17:07:25.286Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
@@ -68,7 +68,7 @@
     </url>
     <url>
         <loc>https://imadsaddik.com/blogs/local-ai-stack-on-linux</loc>
-        <lastmod>2026-01-19T14:47:45.134Z</lastmod>
+        <lastmod>2026-01-19T17:04:11.252Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>

--- a/frontend/src/components/InlineCode.vue
+++ b/frontend/src/components/InlineCode.vue
@@ -1,5 +1,5 @@
 <template>
-  <code v-html="text"></code>
+  <code>{{ text }}</code>
 </template>
 
 <script>

--- a/frontend/tests/unit/components/InlineCode.test.js
+++ b/frontend/tests/unit/components/InlineCode.test.js
@@ -2,8 +2,14 @@ import { mount } from "@vue/test-utils";
 import InlineCode from "@/components/InlineCode.vue";
 
 describe("InlineCode", () => {
-  it("renders the text prop as inner HTML", () => {
+  it("renders the text prop as text content", () => {
+    const wrapper = mount(InlineCode, { props: { text: "-f ~/.ssh/<your_key_name>" } });
+    expect(wrapper.text()).toBe("-f ~/.ssh/<your_key_name>");
+  });
+
+  it("escapes HTML tags in text prop", () => {
     const wrapper = mount(InlineCode, { props: { text: "<strong>code</strong>" } });
-    expect(wrapper.find("code").html()).toContain("<strong>code</strong>");
+    expect(wrapper.text()).toBe("<strong>code</strong>");
+    expect(wrapper.find("strong").exists()).toBe(false);
   });
 });


### PR DESCRIPTION
# Pull request

## Description

This PR solves an issue with `InlineCode` that caused strings like `<placeholder>` to not appear on the website because `InlineCode` was using `v-html`.

Closes #127 

The related issue proposes to use a `Slot`. That is a good idea, but since every article is passing plain text, there is no need to use a `Slot` to render complex HTML inline with text.

## How to test

Use the `InlineCode` component in a paragraph like so:

```vue
<InlineCode text="-f ~/.ssh/<your_key_name>" />
```

Make sure that the output looks like this:

```text
-f ~/.ssh/<your_key_name>
```

## Checklist

Check what applies:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have used LLMs responsibly to assist in writing code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed linting and formatting checks
- [ ] I have updated the documentation accordingly
