### PR TITLE
Remove CORS and HEADERS from vite config

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -43,21 +43,6 @@ export default defineConfig({
   },
   preview: {
     port: 8080,
-    cors: {
-      origin: ["http://localhost:8080"],
-      methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"],
-    },
-    headers: {
-      "X-Frame-Options": "DENY",
-      "X-Content-Type-Options": "nosniff",
-      "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
-      "Cross-Origin-Opener-Policy": "same-origin",
-      "Cross-Origin-Embedder-Policy": "require-corp",
-      "Cross-Origin-Resource-Policy": "same-origin",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Content-Security-Policy":
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' http://localhost:8000 https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';",
-    },
   },
   test: {
     globals: true,


### PR DESCRIPTION
# Pull request

## Description

This PR removes `cors` and `headers` from `preview` in `vite.config.js` because we no longer need them to satisfy the `DAST` step in `CI`.

Closes #131 

## Checklist

Check what applies:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have used LLMs responsibly to assist in writing code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed linting and formatting checks
- [ ] I have updated the documentation accordingly
