### PR TITLE
Make frontend-build wait for e2e-tests and dast-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
   frontend-build:
     name: Frontend
-    needs: e2e-tests
+    needs: [e2e-tests, dast-check]
     uses: ./.github/workflows/frontend-build.yml
 
   pipeline-success:


### PR DESCRIPTION
# Pull request

## Description

This PR adds `DAST` scan as a dependency for the frontend build job. The goal is to not accept any PR that fails the `DAST` scan to ensure that the website is secure.

Closes #136

## Checklist

Check what applies:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have used LLMs responsibly to assist in writing code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed linting and formatting checks
- [ ] I have updated the documentation accordingly
