### PR TITLE
fix: include svg files in prettier frontend pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,6 @@ repos:
         language: node
         language_version: system
         files: ^frontend/.*\.(js|vue|css|scss|html|json|xml|svg)$
-        types_or: [javascript, vue, css, scss, html, json, xml, svg]
 
   - repo: local
     hooks:


### PR DESCRIPTION
This PR updates the prettier-frontend pre-commit hook to include SVG files.

Since @prettier/plugin-xml is already configured in the frontend, Prettier can properly format SVG files. This ensures SVGs are automatically formatted and prevents CI failures caused by unformatted assets.
