### PR TITLE
chore: add markdownlint configuration file

### DIFF
--- a/frontend/.markdownlint.json
+++ b/frontend/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "MD013": {
+    "line_length": 999999,
+    "code_blocks": false,
+    "tables": false
+  },
+  "MD024": {
+    "siblings_only": true
+  }
+}


### PR DESCRIPTION
# Pull request

## Description

This PR adds `.markdownlint.json` to change the behavior of some linting rules.

- `MD013` allows you to write long lines.
- `MD024` allows for duplicate headers.