### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.0.1] - 2026-03-03
+
+### Changed
+
+- **Image transformer:** Migrated the `ImageWithCaption` component from the default inline Markdown image syntax (`![alt](path "caption")`) to a `markdown-it-container` block, enabling rich slot-based captions that support Vue components.
+- **Content:** Updated all `content.md` files across `blogs/`, `astronomy/`, and `courses/` to use the new `::: image` container syntax (143 images across 10 files).
+- **ImageWithCaption component:** Replaced the `image-caption` prop with a default slot, allowing captions to contain arbitrary HTML and Vue components.
+- **Views:** Migrated `HireMe.vue` and `AboutMeFullStory.vue` to use the new slot-based caption API.
+
+### Tests
+
+- Rewrote `transformer-image.test.js` to cover the new container syntax.
+- Updated `ImageWithCaption.test.js` to use slot-based caption testing.
+
 ## [v2.0.0] - 2026-02-26
 
 ### Added
@@ -78,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Monitoring:** Real-time resource tracking with Btop and traffic analysis with GoAccess.
   - **Performance:** Global delivery optimization via Cloudflare CDN.
 
+[v2.0.1]: https://github.com/ImadSaddik/ImadSaddikWebsite/compare/v2.0.0...v2.0.1
 [v2.0.0]: https://github.com/ImadSaddik/ImadSaddikWebsite/compare/v1.1.0...v2.0.0
 [v1.1.0]: https://github.com/ImadSaddik/ImadSaddikWebsite/compare/v1.0.0...v1.1.0
 [v1.0.0]: https://github.com/ImadSaddik/ImadSaddikWebsite/releases/tag/v1.0.0

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,7 +24,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # After yield, we put code that will be executed after the application has finished.
 
 
-app = FastAPI(title="API for ImadSaddik.com", version="2.0.0", lifespan=lifespan)
+app = FastAPI(title="API for ImadSaddik.com", version="2.0.1", lifespan=lifespan)
 
 app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
 app.add_exception_handler(HTTPException, http_exception_handler)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
# Pull request

## Description

Bumps the project version from `2.0.0` to `2.0.1` following the merge of #199.

## Changes

- `frontend/package.json` — version `2.0.0` → `2.0.1`
- `backend/main.py` — FastAPI app version `2.0.0` → `2.0.1`
- `CHANGELOG.md` — added `v2.0.1` entry documenting the image transformer refactor
