### PR TITLE
fix: enhance 404 error handling in ArticlePage component

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -8,25 +8,25 @@
 >
     <url>
         <loc>https://imadsaddik.com/</loc>
-        <lastmod>2026-03-04T07:16:59.279Z</lastmod>
+        <lastmod>2026-03-05T08:00:03.849Z</lastmod>
         <changefreq>daily</changefreq>
         <priority>1.0</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/about-me</loc>
-        <lastmod>2026-03-04T07:16:59.279Z</lastmod>
+        <lastmod>2026-03-05T08:00:03.849Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/hire-me</loc>
-        <lastmod>2026-03-04T07:16:59.279Z</lastmod>
+        <lastmod>2026-03-05T08:00:03.849Z</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
         <loc>https://imadsaddik.com/resume</loc>
-        <lastmod>2026-03-04T07:16:59.279Z</lastmod>
+        <lastmod>2026-03-05T08:00:03.849Z</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.5</priority>
     </url>

--- a/frontend/src/views/ArticlePage.vue
+++ b/frontend/src/views/ArticlePage.vue
@@ -165,7 +165,12 @@ export default {
     },
     handleLoadError(error) {
       console.error("Failed to load article:", error);
-      this.$router.replace({ name: ROUTES.NOT_FOUND.name });
+      this.$router.replace({
+        name: ROUTES.NOT_FOUND.name,
+        params: { pathMatch: this.$route.path.split("/").slice(1) },
+        query: this.$route.query,
+        hash: this.$route.hash,
+      });
     },
     clearReadTimer() {
       if (this.readTimer) {


### PR DESCRIPTION
# Pull request

## Description

This PR updates `this.$router.replace` in `ArticlePage.vue` to keep the current URL path when an article is not found.

Before, if you visited an invalid article link like `https://imadsaddik.com/blogs/oops`, the app showed the 404 page but changed the URL back to the home page (`https://imadsaddik.com/`).

Now, the app still shows the 404 page, but the URL correctly stays as `https://imadsaddik.com/blogs/oops`.