### PR TITLE
fix: update e2e test to check for the same url

### DIFF
--- a/frontend/tests/e2e/navigation.spec.js
+++ b/frontend/tests/e2e/navigation.spec.js
@@ -110,22 +110,23 @@ test.describe("Navigation", () => {
       await expect(page).toHaveURL(ROUTES.HOME.path);
     });
 
-    test("should redirect invalid blog slug to 404 page", async ({ page }) => {
-      const url = `${ROUTES.BLOGS_HUB.path}/this-blog-does-not-exist-at-all`;
-      await page.goto(url);
-      await expect(page).toHaveURL(url);
-    });
+    const testCases = [
+      { name: "blog", path: ROUTES.BLOGS_HUB.path, slug: "this-blog-does-not-exist-at-all" },
+      { name: "course", path: ROUTES.COURSES_HUB.path, slug: "this-course-does-not-exist-at-all" },
+      { name: "astronomy", path: ROUTES.ASTRONOMY_HUB.path, slug: "non-existent-astronomy-article" },
+    ];
 
-    test("should redirect invalid course slug to 404 page", async ({ page }) => {
-      const url = `${ROUTES.COURSES_HUB.path}/this-course-does-not-exist-at-all`;
-      await page.goto(url);
-      await expect(page).toHaveURL(url);
-    });
+    for (const { name, path, slug } of testCases) {
+      test(`should display 404 page for invalid ${name} slug`, async ({ page }) => {
+        const url = `${path}/${slug}`;
+        await page.goto(url);
 
-    test("should redirect invalid astronomy slug to 404 page", async ({ page }) => {
-      const url = `${ROUTES.ASTRONOMY_HUB.path}/non-existent-astronomy-article`;
-      await page.goto(url);
-      await expect(page).toHaveURL(url);
-    });
+        await expect(page).toHaveURL(url);
+        await expect(page).toHaveTitle("Page not found");
+        await expect(page.locator(".not-found-page-container p")).toContainText(
+          "The page you are looking for does not exist"
+        );
+      });
+    }
   });
 });


### PR DESCRIPTION
# Pull request

## Description

This PR fixes a test that is now failing after merging #205.

An invalid article slug does not redirect the user to the home page. Instead, we keep them in that URL they requested, but we show the 404 view.