### PR TITLE
fix: Handle orphaned gunicorn processes on deploy

### DIFF
--- a/infrastructure/scripts/gunicorn_start
+++ b/infrastructure/scripts/gunicorn_start
@@ -6,7 +6,8 @@ SOCKFILE=/web_app/backend/venv/run/gunicorn.sock
 USER=imad
 GROUP=imad
 NUM_WORKERS=1
-TIMEOUT=120
+TIMEOUT=30
+GRACEFUL_TIMEOUT=5
 
 # Gunicorn needs to use Uvicorn's worker class for FastAPI
 WORKER_CLASS=uvicorn.workers.UvicornWorker
@@ -30,6 +31,7 @@ exec venv/bin/gunicorn main:app \
   --workers $NUM_WORKERS \
   --worker-class $WORKER_CLASS \
   --timeout $TIMEOUT \
+  --graceful-timeout $GRACEFUL_TIMEOUT \
   --user=$USER --group=$GROUP \
   --bind=unix:$SOCKFILE \
   --forwarded-allow-ips="$FORWARDED_ALLOW_IPS" \

--- a/infrastructure/supervisor/imadsaddik.conf
+++ b/infrastructure/supervisor/imadsaddik.conf
@@ -4,3 +4,6 @@ user = imad
 stdout_logfile = /web_app/backend/venv/logs/supervisor.log
 redirect_stderr = true
 environment=LANG=en_US.UTF-8,LC_ALL=en_US.UTF-8
+stopasgroup = true
+killasgroup = true
+stopwaitsecs = 10


### PR DESCRIPTION
# Pull request

## Description

Supervisor was only sending `SIGTERM` to the `gunicorn` master process, leaving worker sub-processes orphaned after each deploy.

### Changes:

- Add `stopasgroup = true` and `killasgroup = true` to supervisor config so the stop signal is sent to the entire process group
- Lower gunicorn `--timeout` from 120s to 30s (kills stuck workers faster)
- Add `--graceful-timeout 5s` (in-flight requests drain window before workers are killed)
- `stopwaitsecs = 10` gives supervisor enough headroom over the graceful timeout before forcing a SIGKILL