### PR TITLE
chore: bump flatted from 3.4.1 to 3.4.2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,8 @@
   "pnpm": {
     "overrides": {
       "minimatch": "^10.2.3",
-      "ajv": "^6.14.0"
+      "ajv": "^6.14.0",
+      "flatted": "^3.4.2"
     }
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   minimatch: ^10.2.3
   ajv: ^6.14.0
+  flatted: ^3.4.2
 
 importers:
 
@@ -1229,8 +1230,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.1:
-    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -2686,7 +2687,7 @@ snapshots:
     dependencies:
       '@vitest/utils': 4.0.14
       fflate: 0.8.2
-      flatted: 3.4.1
+      flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.15
@@ -3238,10 +3239,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.1
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.4.1: {}
+  flatted@3.4.2: {}
 
   follow-redirects@1.15.11: {}
 


### PR DESCRIPTION
# Pull request

## Description

This PR resolves a high severity vulnerability by upgrading the `flatted` package to `v3.4.2`.

## How to test

Run unit and e2e tests.