### PR TITLE
build(deps): fix postcss vulnerability by overriding to ^8.5.10

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
       "follow-redirects": "^1.16.0",
       "minimatch": "^10.2.3",
       "picomatch": "^4.0.4",
+      "postcss": "^8.5.10",
       "yaml": "^2.8.3"
     }
   }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   follow-redirects: ^1.16.0
   minimatch: ^10.2.3
   picomatch: ^4.0.4
+  postcss: ^8.5.10
   yaml: ^2.8.3
 
 importers:
@@ -1701,8 +1702,8 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -2798,7 +2799,7 @@ snapshots:
       '@vue/shared': 3.5.29
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.8
+      postcss: 8.5.10
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.29':
@@ -3769,7 +3770,7 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.8:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -4114,7 +4115,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.10
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Description
Fixes a moderate XSS vulnerability in PostCSS (GHSA-qx2v-qp2m-jg93) by overriding its version to `^8.5.10` in `package.json`.

## How to test
- `pnpm audit` returns no vulnerabilities.
- `npm run lint` and `npm run test:run` pass successfully.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have used LLMs responsibly to assist in writing code
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed linting and formatting checks