### PR TITLE
ci: change the pipeline-success job to fail when checks fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,13 @@ jobs:
     name: Pipeline success
     needs: frontend-build
     runs-on: ubuntu-latest
-    if: success()
+    if: always()
     steps:
-      - run: echo "Pipeline completed successfully!"
+      - name: Pipeline succeeded
+        if: needs.frontend-build.result == 'success'
+        run: echo "All checks passed successfully!"
+      - name: Pipeline failed
+        if: needs.frontend-build.result != 'success'
+        run: |
+          echo "Some checks failed, were cancelled, or skipped."
+          exit 1


### PR DESCRIPTION
# Pull request

## Description

This update modifies the `pipeline-success` job to use the `always()` condition and explicitly verify the status of the final build job.

Previously, early CI failures caused this required check to be skipped, which created a confusing developer experience by hiding the failure state behind a neutral gray icon instead of blocking the merge visually.

By actively forcing an `exit 1` when upstream jobs fail or skip, this change creates a clear, red failure state in the pull request UI that properly communicates when the pipeline is broken.

Closes #272 
