### PR TITLE
feat: migrate to pnpm v11

### DIFF
--- a/.github/workflows/daily-deep-security-scan.yml
+++ b/.github/workflows/daily-deep-security-scan.yml
@@ -99,9 +99,9 @@ jobs:
         run: python -m tests.test_data
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: "10"
+          version: "11"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -100,9 +100,9 @@ jobs:
           MEILISEARCH_INDEX_NAME: ${{ env.MEILISEARCH_INDEX_NAME }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: "10"
+          version: "11"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: "10"
+          version: "11"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/frontend-lint-format-check.yml
+++ b/.github/workflows/frontend-lint-format-check.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: "10"
+          version: "11"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: "10"
+          version: "11"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/frontend-vulnerability-check.yml
+++ b/.github/workflows/frontend-vulnerability-check.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: "10"
+          version: "11"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,10 +140,10 @@ The frontend is built with [Vue.js](https://vuejs.org/) and [Vite](https://vitej
 ### Prerequisites (frontend)
 
 - [Node.js](https://nodejs.org/)
-- [pnpm](https://pnpm.io/) (v11)
+- [pnpm](https://pnpm.io/) (v11+)
 
 > [!NOTE]
-> Please install `pnpm` v11 because it introduces supply-chain protection by default.
+> Please install `pnpm` v11+ because it introduces supply-chain protection by default.
 
 ### Setup (frontend)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,10 @@ The frontend is built with [Vue.js](https://vuejs.org/) and [Vite](https://vitej
 ### Prerequisites (frontend)
 
 - [Node.js](https://nodejs.org/)
-- [pnpm](https://pnpm.io/) (v10+)
+- [pnpm](https://pnpm.io/) (v11)
+
+> [!NOTE]
+> Please install `pnpm` v11 because it introduces supply-chain protection by default.
 
 ### Setup (frontend)
 

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,0 @@
-shamefully-hoist=true

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+shamefullyHoist: true
 overrides:
   ajv: "^6.14.0"
   brace-expansion: "^5.0.5"

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -9,3 +9,5 @@ overrides:
   postcss: "^8.5.10"
   ws: "^8.20.1"
   yaml: "^2.8.3"
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
# Pull request

## Description

This PR migrates CI jobs to use `pnpm` v11 and `pnpm/action-setup` v6. It also moves every setting from `.npmrc` to `pnpm-workspace.yaml`

Closes #274 