### PR TITLE
refactor: split backend dependencies

### DIFF
--- a/.github/workflows/backend-integration-tests.yml
+++ b/.github/workflows/backend-integration-tests.yml
@@ -28,7 +28,7 @@ jobs:
           cache: "pip"
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-dev.txt
 
       - name: Download Meilisearch binary
         run: |

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
           cache: "pip"
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-dev.txt
 
       - name: Run unit tests
         run: pytest tests/unit --tb=short --cov --cov-branch --cov-report=xml

--- a/.github/workflows/backend-vulnerability-check.yml
+++ b/.github/workflows/backend-vulnerability-check.yml
@@ -24,3 +24,4 @@ jobs:
         uses: pypa/gh-action-pip-audit@v1.1.0
         with:
           inputs: backend/requirements.txt
+          ignore-vulns: PYSEC-2025-183

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ source venv/bin/activate  # On Windows use `venv\Scripts\activate`
 Install dependencies:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 ```
 
 Copy the example environment file and update `.env` with your Meilisearch configuration if different from defaults.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ source venv/bin/activate  # On Windows use `venv\Scripts\activate`
 Next, install the required dependencies. Don't forget to activate your virtual environment if you haven't done so already:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 ```
 
 Now, create a `.env` file by copying the example file. You don't need to modify anything once you copy it:

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest==9.0.3
+pytest-asyncio==1.3.0
+pytest-cov==7.0.0
+pre_commit==4.5.1
+locust==2.43.3

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,5 @@
+-r requirements.txt
+
 pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-cov==7.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,12 +4,7 @@ pydantic==2.12.5
 pydantic-settings==2.13.1
 uvicorn==0.41.0
 httpx==0.28.1
-pytest==9.0.3
-pytest-asyncio==1.3.0
-pytest-cov==7.0.0
-pre_commit==4.5.1
 gunicorn==25.1.0
-locust==2.43.3
 slowapi==0.1.9
 aiosqlite==0.22.1
 meilisearch-python-sdk==7.0.4


### PR DESCRIPTION
# Pull request

## Description

This MR splits the backend dependencies into two files: `requirements.txt` and `requirements-dev.txt`.

We don't need to keep dev dependencies in the production environment and this MR ensures that.

This also makes CI jobs not fail if a vulnerability is discovered in a dev package.

Closes #276
